### PR TITLE
On fillCatalogue ignore doocs intenal specific properties

### DIFF
--- a/include/DoocsBackend.h
+++ b/include/DoocsBackend.h
@@ -14,6 +14,9 @@
 
 namespace ChimeraTK {
 
+   const std::string IGNORE_PATTERNS[] = {".HIST",".FILT",".EGU",".DESC",
+    ".HSTAT", "._HIST",".LIST",".SAVE",".COMMENT",".XEGU",".POLYPARA"};
+   const size_t SIZE_IGNORE_PATTERNS = std::extent<decltype(IGNORE_PATTERNS)>::value;
   /** Backend to access DOOCS control system servers.
    *
    *  The sdm URI should look like this:
@@ -91,6 +94,8 @@ namespace ChimeraTK {
 
     template<typename UserType>
     friend class DoocsBackendRegisterAccessor;
+  private:
+    bool ignorePattern(std::string name, std::string pattern) const;
   };
 
 } // namespace ChimeraTK

--- a/src/DoocsBackend.cc
+++ b/src/DoocsBackend.cc
@@ -109,6 +109,11 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
+  bool DoocsBackend::ignorePattern(std::string name, std::string pattern) const {
+    return boost::algorithm::ends_with(name, pattern);
+  }
+
+  /********************************************************************************************************************/
   void DoocsBackend::fillCatalogue(std::string fixedComponents, long level) const {
     // obtain list of elements within the given partial address
     EqAdr ea;
@@ -138,6 +143,17 @@ namespace ChimeraTK {
       }
       else {
         // this is a property: create RegisterInfo entry and set its name
+        bool skipRegister =false;
+        for(uint i= 0; i < SIZE_IGNORE_PATTERNS; i++){
+          std::string pattern = IGNORE_PATTERNS[i];
+          if (ignorePattern(name, pattern)){
+            skipRegister = true;
+            break;
+          }
+        }
+        if (skipRegister){
+          continue;
+        }
         boost::shared_ptr<DoocsBackendRegisterInfo> info(new DoocsBackendRegisterInfo());
         std::string fqn = fixedComponents + "/" + name;
         info->name = fqn.substr(std::string(_serverAddress).length());


### PR DESCRIPTION
For LLRF.CONTROLLER it skipped 488477 properties out of 830460 and filled the catalogue in ca. 24 minutes as opposed to ca. 59 minutes.