### PR TITLE
project-template: make config_generator_project future proof

### DIFF
--- a/cmake/config_generator_project.cmake
+++ b/cmake/config_generator_project.cmake
@@ -22,9 +22,7 @@ find_package(ConfigGenerator 02.00 REQUIRED)
 set(DESTDIR share/ConfigGenerator-${PROJECT_NAME}-${${PROJECT_NAME}_MAJOR_VERSION}-${${PROJECT_NAME}_MINOR_VERSION})
 
 # copy all script files from config generator to our build directory
-file(GLOB scripts RELATIVE ${ConfigGenerator_DIR} ${ConfigGenerator_DIR}/*.sh ${ConfigGenerator_DIR}/*.py
-                           ${ConfigGenerator_DIR}/*.inc ${ConfigGenerator_DIR}/ConfigGenerator/*.py
-                           ${ConfigGenerator_DIR}/TestFacility/*.py)
+file(GLOB_RECURSE scripts RELATIVE ${ConfigGenerator_DIR} ${ConfigGenerator_DIR}/*)
 foreach(script ${scripts})
   configure_file("${ConfigGenerator_DIR}/${script}" "${PROJECT_BINARY_DIR}/${script}" COPYONLY)
 endforeach()


### PR DESCRIPTION
The upcoming version of the config generator script package will need
more files to be copied into the build directory. This change simply
copies all files and does not rely on a particular structure.
