### PR TITLE
fix: tests fail with latest DOOCS version

### DIFF
--- a/tests/doocsDummy_rpc_server.conf
+++ b/tests/doocsDummy_rpc_server.conf
@@ -1,9 +1,9 @@
-eq_conf: 
+eq_conf:
 
 oper_uid: 	-1
-oper_gid: 	405
-xpert_uid: 	1000
-xpert_gid: 	1000
+oper_gid: 	-1
+xpert_uid: 	-1
+xpert_gid: 	-1
 ring_buffer: 	10000
 memory_buffer: 	500
 
@@ -14,10 +14,10 @@ SVR.RPC_NUMBER:  	610498009
 SVR.NAME:  	"DUMMY._SVR"
 SVR.RATE:       57005  48879  0  0
 SVR.BPN:	6000
+SVR.FACILITY: "TEST.DOOCS"
 }
 eq_fct_name: 	"MYDUMMY"
 eq_fct_type: 	10
 {
 NAME:  	"MYDUMMY"
 }
-


### PR DESCRIPTION
Reason was missing SVR.FACILITY setting in DOOCS conf file, in which
case DOOCS seems to reject all write attempts.