### PR TITLE
feat: make catalogue fetcher less verbose

### DIFF
--- a/include/CatalogueFetcher.h
+++ b/include/CatalogueFetcher.h
@@ -19,6 +19,9 @@ class CatalogueFetcher {
   std::future<void> cancelFlag_;
   DoocsBackendRegisterCatalogue catalogue_;
   bool locationLookupError_{false};
+  std::string _failedPropertyFirst;
+  std::string _failedPropertyError;
+  size_t _failedPropertyCount{0};
 
   void fillCatalogue(std::string fixedComponents, long level);
   bool isCancelled() const { return (cancelFlag_.wait_for(std::chrono::microseconds(0)) == std::future_status::ready); }


### PR DESCRIPTION
In some situations (automated config tests) the catalogue fetcher will
always spam a significant amount of warnings due to stale data, without
harm coming from those not yet initialised properties. This can make
debugging of other issues harder, because it produces so much output.